### PR TITLE
chore(APE-1097): Adds dependency review workflow

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,20 @@
+name: Dependency Review
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Dependency Review
+        uses: actions/dependency-review-action@v4
+        with:
+          fail-on-severity: critical


### PR DESCRIPTION
## Summary

- Add GitHub Actions workflow for dependency review on pull requests
- Configured to fail on critical severity vulnerabilities using `actions/dependency-review-action@v4`

## References

- https://github.com/actions/dependency-review-action

🤖 Generated with [Claude Code](https://claude.com/claude-code)