### PR TITLE
ACQ-6306: Fix pnpm-workspace.yaml settings nesting

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,7 +3,6 @@ ignoredBuiltDependencies:
   - core-js-pure
   - fsevents
 
-settings:
-  autoInstallPeers: true
-  minimumReleaseAge: 10080
-  strictPeerDependencies: false
+minimumReleaseAge: 10080
+minimumReleaseAgeExclude:
+  - '@airtasker/*'


### PR DESCRIPTION
## Summary
- Remove invalid `settings:` nesting from pnpm-workspace.yaml
- Remove unnecessary `autoInstallPeers: true` configuration
- Remove unnecessary `strictPeerDependencies: false` configuration (default)
- Keep only `minimumReleaseAge` and `minimumReleaseAgeExclude` at root level

This aligns with the pnpm workspace specification and matches the configuration used in the web repository.